### PR TITLE
fix exception on building gauges for vms on offline nodes

### DIFF
--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -234,7 +234,7 @@ class ClusterResourcesCollector(object):
             restype = resource['type']
 
             if restype in info_lookup:
-                label_values = [resource[key] for key in info_lookup[restype]['labels']]
+                label_values = [resource[key] if key in resource else 'unknown' for key in info_lookup[restype]['labels']]
                 info_lookup[restype]['gauge'].add_metric(label_values, 1)
 
             label_values = [resource['id']]


### PR DESCRIPTION
when a proxmox node is offline, the containers/vms on that node don't have a 'name' label.