### PR TITLE
Fixed issues with VM names when PVE is down.

### DIFF
--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -234,7 +234,7 @@ class ClusterResourcesCollector(object):
             restype = resource['type']
 
             if restype in info_lookup:
-                label_values = [resource[key] for key in info_lookup[restype]['labels']]
+                label_values = [resource.get(key, '') for key in info_lookup[restype]['labels']]
                 info_lookup[restype]['gauge'].add_metric(label_values, 1)
 
             label_values = [resource['id']]


### PR DESCRIPTION
Fixes the same issue as in #14 with the requested change to use `resource.get(key, 'unknown')`- this bug prevents us from alerting when any PVE node is down in the cluster.

I've confirmed in our local environment that this fixes the problem.