### PR TITLE
Pin pylint >=2.0 in order to avoid useless-object-inheritance false positives

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
-pylint
+pylint<2.0
 pyflakes


### PR DESCRIPTION
Pylint 2.0 dropped support for Python 2. Stick to the 1.9 release in order to have feature parity between the lint checks under Python 2 and Python 3.