### PR TITLE
added config read from pve

### DIFF
--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -246,7 +246,7 @@ class ClusterResourcesCollector(object):
 
 class ClusterNodeConfigCollector(object):
     """
-    Collects Proxmox VE VM information directly from config, i.e. boot, name, onboot, etc. 
+    Collects Proxmox VE VM information directly from config, i.e. boot, name, onboot, etc.
     For manual test: "pvesh get /nodes/<node>/<type>/<vmid>/config"
 
     # HELP pve_vm_config_onboot Proxmox vm config onboot value
@@ -257,7 +257,7 @@ class ClusterNodeConfigCollector(object):
     def __init__(self, pve):
         self._pve = pve
 
-    def collect(self):
+    def collect(self): # pylint: disable=missing-docstring
         metrics = {
             'onboot': GaugeMetricFamily(
                 'pve_vm_config_onboot',

--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -251,7 +251,7 @@ class ClusterNodeConfigCollector(object):
 
     # HELP pve_vm_config_onboot Proxmox vm config onboot value
     # TYPE pve_vm_config_onboot gauge
-    pve_vm_config_onboot{id="qemu/113",node="XXXX",type="qemu"} 1.0
+    pve_onboot_status{id="qemu/113",node="XXXX",type="qemu"} 1.0
     """
 
     def __init__(self, pve):

--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -249,8 +249,8 @@ class ClusterNodeConfigCollector(object):
     Collects Proxmox VE VM information directly from config, i.e. boot, name, onboot, etc.
     For manual test: "pvesh get /nodes/<node>/<type>/<vmid>/config"
 
-    # HELP pve_vm_config_onboot Proxmox vm config onboot value
-    # TYPE pve_vm_config_onboot gauge
+    # HELP pve_onboot_status Proxmox vm config onboot value
+    # TYPE pve_onboot_status gauge
     pve_onboot_status{id="qemu/113",node="XXXX",type="qemu"} 1.0
     """
 

--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -260,12 +260,8 @@ class ClusterNodeConfigCollector(object):
     def collect(self): # pylint: disable=missing-docstring
         metrics = {
             'onboot': GaugeMetricFamily(
-                'pve_vm_config_onboot',
+                'pve_onboot_status',
                 'Proxmox vm config onboot value',
-                labels=['id', 'node', 'type']),
-            'memory': GaugeMetricFamily(
-                'pve_vm_config_memory',
-                'Proxmox vm config memory value',
                 labels=['id', 'node', 'type']),
         }
 

--- a/src/pve_exporter/collector.py
+++ b/src/pve_exporter/collector.py
@@ -244,6 +244,49 @@ class ClusterResourcesCollector(object):
 
         return itertools.chain(metrics.values(), info_metrics.values())
 
+class NodeVmConfigCollector(object):
+    """
+    Collects Proxmox VE VM information directly from config, i.e. boot, name, onboot, etc.
+    For manual test: "pvesh get /nodes/<node>/<type>/<vmid>/config"
+
+    # HELP pve_vm_config_onboot Proxmox vm config onboot value
+    # TYPE pve_vm_config_onboot gauge
+    pve_vm_config_onboot{id="qemu/113",node="XXXX",type="qemu"} 1.0
+    """
+
+    def __init__(self, pve):
+        self._pve = pve
+
+    def collect(self):
+        metrics = {
+            'onboot': GaugeMetricFamily(
+                'pve_vm_config_onboot',
+                'Proxmox vm config onboot value',
+                labels=['id','node', 'type']),
+            'memory': GaugeMetricFamily(
+                'pve_vm_config_memory',
+                'Proxmox vm config memory value',
+                labels=['id','node', 'type']),
+        }
+
+        for node in self._pve.nodes.get():
+            # Qemu
+            vmtype = 'qemu'
+            for vm in self._pve.nodes(node['node']).qemu.get():
+                for key, metric_value in self._pve.nodes(node['node']).qemu(vm['vmid']).config.get().items():
+                    label_values = ["%s/%s" % (vmtype, vm['vmid']), node['node'], vmtype]
+                    if key in metrics:
+                        metrics[key].add_metric(label_values, metric_value)
+            # LXC
+            vmtype = 'lxc'
+            for vm in self._pve.nodes(node['node']).lxc.get():
+                for key, metric_value in self._pve.nodes(node['node']).lxc(vm['vmid']).config.get().items():
+                    label_values = ["%s/%s" % (vmtype, vm['vmid']), node['node'], vmtype]
+                    if key in metrics:
+                        metrics[key].add_metric(label_values, metric_value)
+
+        return metrics.values()
+
 def collect_pve(config, host):
     """Scrape a host and return prometheus text format for it"""
 
@@ -254,5 +297,6 @@ def collect_pve(config, host):
     registry.register(ClusterResourcesCollector(pve))
     registry.register(ClusterNodeCollector(pve))
     registry.register(ClusterInfoCollector(pve))
+    registry.register(NodeVmConfigCollector(pve))
     registry.register(VersionCollector(pve))
     return generate_latest(registry)


### PR DESCRIPTION
Hi, in our case we want to track if virtual is running and also have onboot variable set, so it does boot automatically next time. In this case var is not set if its false, so rule on prometheus side should look for absent(...), because if not set it also missing from pve config files on FS.

So this PR should do it, I know am not skilled programmer. Even if this get you idea for rework its ok.

I wanted not to use diffrent loops for qemu and lxc, but can't get working diffrent query where could be lxc and qemu variables.

Thank you!