### PR TITLE
Collector for storage content metrics ctime, size and verification state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,6 +139,9 @@ The ``target`` request parameter defaults to ``localhost``. Hence if
 ``pve_exporter`` is deployed directly on the proxmox host, ``target``
 can be omitted.
 
+Visit http://localhost:9221/storage?target=1.2.3.4&node=proxmox&storage=local
+to export storage content metrics for a specific node and storage.
+
 Use the `--collector.X` / `--no-collector.X` flags to enable disable selected
 collectors.
 
@@ -265,6 +268,19 @@ Here's an example of the metrics exported.
     pve_storage_info{content="iso,vztmpl,rootdir",id="storage/proxmox/local",node="proxmox",plugintype="dir",storage="local"} 1.0
     pve_storage_info{content="backup",id="storage/proxmox/local-lvm",node="proxmox",plugintype="lvm",storage="local-lvm"} 1.0
     pve_storage_info{content="images",id="storage/proxmox/vms",node="proxmox",plugintype="rbd",storage="vms"} 1.0
+    # HELP pve_storage_contents_ctime_timestamp_seconds Proxmox storage content creation time
+    # TYPE pve_storage_contents_ctime_timestamp_seconds gauge
+    pve_storage_contents_ctime_timestamp_seconds{id="content/proxmox/local:backup/vzdump-qemu-100-2024_01_01-00_00_00.tar.zst"} 1.7040612e+09
+    # HELP pve_storage_contents_bytes Proxmox storage content size in bytes
+    # TYPE pve_storage_contents_bytes gauge
+    pve_storage_contents_bytes{id="content/proxmox/local:backup/vzdump-qemu-100-2024_01_01-00_00_00.tar.zst"} 1.073741824e+010
+    # HELP pve_storage_contents_verification Proxmox storage content verification present
+    # TYPE pve_storage_contents_verification gauge
+    pve_storage_contents_verification{id="content/proxmox/local:backup/vzdump-qemu-100-2024_01_01-00_00_00.tar.zst"} 1.0
+    # HELP pve_storage_contents_info Proxmox storage content info
+    # TYPE pve_storage_contents_info gauge
+    pve_storage_contents_info{content="backup",guest="qemu/100",id="content/proxmox/local:backup/vzdump-qemu-100-2024_01_01-00_00_00.tar.zst",node="proxmox",storage="local",verification_state="verified",volid="local:backup/vzdump-qemu-100-2024_01_01-00_00_00.tar.zst"} 1.0
+    pve_storage_contents_info{content="iso",guest="",id="content/proxmox/local:iso/ubuntu-22.04.iso",node="proxmox",storage="local",verification_state="",volid="local:iso/ubuntu-22.04.iso"} 1.0
     # HELP pve_node_info Node info
     # TYPE pve_node_info gauge
     pve_node_info{id="node/proxmox",level="",name="proxmox",nodeid="0"} 1.0

--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -21,6 +21,7 @@ from pve_exporter.collector.node import (
     NodeReplicationCollector,
     SubscriptionCollector
 )
+from pve_exporter.collector.storage import StorageCollector
 
 CollectorsOptions = collections.namedtuple('CollectorsOptions', [
     'status',
@@ -62,5 +63,16 @@ def collect_pve(config, host, cluster, node, options: CollectorsOptions):
         registry.register(NodeConfigCollector(pve))
     if node and options.replication:
         registry.register(NodeReplicationCollector(pve))
+
+    return generate_latest(registry)
+
+
+def collect_storage(config, host, node, storage):
+    """Scrape storage metrics and return prometheus text format for it"""
+
+    pve = ProxmoxAPI(host, **config)
+
+    registry = CollectorRegistry()
+    registry.register(StorageCollector(pve, node, storage))
 
     return generate_latest(registry)

--- a/src/pve_exporter/collector/storage.py
+++ b/src/pve_exporter/collector/storage.py
@@ -1,0 +1,58 @@
+"""
+Prometheus collectors for Proxmox VE storage.
+"""
+
+from prometheus_client.core import GaugeMetricFamily
+from proxmoxer.core import ResourceException
+import logging
+
+class StorageCollector:
+    """
+    Collects Proxmox VE storage information.
+    """
+
+    def __init__(self, pve, node, storage):
+        self._pve = pve
+        self._node = node
+        self._storage = storage
+
+    def collect(self):
+        metrics = {
+            'ctime': GaugeMetricFamily(
+                'pve_storage_contents_ctime',
+                'Proxmox storage contents ctime',
+                labels=['node', 'storage', 'vmid', 'content', 'volid']),
+            'size': GaugeMetricFamily(
+                'pve_storage_contents_bytes',
+                'Proxmox storage contents size in bytes',
+                labels=['node', 'storage', 'vmid', 'content', 'volid']),
+            'verification': GaugeMetricFamily(
+                'pve_storage_contents_verification',
+                'Proxmox storage contents verification state',
+                labels=['node', 'storage', 'vmid', 'content', 'volid', 'state']),
+        }
+
+        try:
+            contents = self._pve.nodes(self._node).storage(self._storage).content.get()
+            for item in contents:
+                metrics['ctime'].add_metric(
+                    [self._node, self._storage, str(item['vmid']), item['content'], item['volid']],
+                    item['ctime']
+                )
+
+                metrics['size'].add_metric(
+                    [self._node, self._storage, str(item['vmid']), item['content'], item['volid']],
+                    item['size']
+                )
+
+                if item['verification']:
+                    metrics['verification'].add_metric(
+                        [self._node, self._storage, str(item['vmid']), item['content'], item['volid'], item['verification']['state']],
+                        1
+                    )
+        except ResourceException as e:
+            # Log the error and return an empty list of metrics
+            logging.error(f"Error fetching storage contents: {e}")
+            return metrics.values()
+
+        return metrics.values()

--- a/src/pve_exporter/collector/storage.py
+++ b/src/pve_exporter/collector/storage.py
@@ -45,7 +45,7 @@ class StorageCollector:
                     item['size']
                 )
 
-                if item['verification']:
+                if 'verification' in item:
                     metrics['verification'].add_metric(
                         [self._node, self._storage, str(item['vmid']), item['content'], item['volid'], item['verification']['state']],
                         1

--- a/src/pve_exporter/collector/storage.py
+++ b/src/pve_exporter/collector/storage.py
@@ -2,13 +2,30 @@
 Prometheus collectors for Proxmox VE storage.
 """
 
+import itertools
+import logging
+
 from prometheus_client.core import GaugeMetricFamily
 from proxmoxer.core import ResourceException
-import logging
+
+
+def _content_id(node, volid):
+    return f"content/{node}/{volid}"
+
+
+def _guest_label(item):
+    vmid = item.get('vmid', 0)
+    if not vmid:
+        return ''
+    volid = item.get('volid', '')
+    if 'vzdump-lxc-' in volid or item.get('content') == 'rootdir':
+        return f"lxc/{vmid}"
+    return f"qemu/{vmid}"
+
 
 class StorageCollector:
     """
-    Collects Proxmox VE storage information.
+    Collects Proxmox VE storage content information.
     """
 
     def __init__(self, pve, node, storage):
@@ -16,43 +33,54 @@ class StorageCollector:
         self._node = node
         self._storage = storage
 
-    def collect(self):
+    def collect(self):  # pylint: disable=missing-docstring
+        info_metric = GaugeMetricFamily(
+            'pve_storage_contents_info',
+            'Proxmox storage content info',
+            labels=['id', 'node', 'storage', 'content', 'volid', 'guest', 'verification_state'],
+        )
+
         metrics = {
             'ctime': GaugeMetricFamily(
-                'pve_storage_contents_ctime',
-                'Proxmox storage contents ctime',
-                labels=['node', 'storage', 'vmid', 'content', 'volid']),
+                'pve_storage_contents_ctime_timestamp_seconds',
+                'Proxmox storage content creation time',
+                labels=['id']),
             'size': GaugeMetricFamily(
                 'pve_storage_contents_bytes',
-                'Proxmox storage contents size in bytes',
-                labels=['node', 'storage', 'vmid', 'content', 'volid']),
+                'Proxmox storage content size in bytes',
+                labels=['id']),
             'verification': GaugeMetricFamily(
                 'pve_storage_contents_verification',
-                'Proxmox storage contents verification state',
-                labels=['node', 'storage', 'vmid', 'content', 'volid', 'state']),
+                'Proxmox storage content verification present',
+                labels=['id']),
         }
 
         try:
             contents = self._pve.nodes(self._node).storage(self._storage).content.get()
             for item in contents:
-                metrics['ctime'].add_metric(
-                    [self._node, self._storage, str(item['vmid']), item['content'], item['volid']],
-                    item['ctime']
+                content_id = _content_id(self._node, item['volid'])
+                verification = item.get('verification') or {}
+                verification_state = verification.get('state', '')
+
+                info_metric.add_metric(
+                    [
+                        content_id,
+                        self._node,
+                        self._storage,
+                        item['content'],
+                        item['volid'],
+                        _guest_label(item),
+                        verification_state,
+                    ],
+                    1,
                 )
 
-                metrics['size'].add_metric(
-                    [self._node, self._storage, str(item['vmid']), item['content'], item['volid']],
-                    item['size']
-                )
+                label_values = [content_id]
+                metrics['ctime'].add_metric(label_values, item['ctime'])
+                metrics['size'].add_metric(label_values, item['size'])
+                if verification_state:
+                    metrics['verification'].add_metric(label_values, 1)
+        except ResourceException as error:
+            logging.error("Error fetching storage contents: %s", error)
 
-                if 'verification' in item:
-                    metrics['verification'].add_metric(
-                        [self._node, self._storage, str(item['vmid']), item['content'], item['volid'], item['verification']['state']],
-                        1
-                    )
-        except ResourceException as e:
-            # Log the error and return an empty list of metrics
-            logging.error(f"Error fetching storage contents: {e}")
-            return metrics.values()
-
-        return metrics.values()
+        return itertools.chain(metrics.values(), [info_metric])

--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -74,7 +74,7 @@ class PveExporterApplication:
 
         return response
 
-    def on_storage(self, module='default', target='localhost', node='1', storage='local'):
+    def on_storage(self, module='default', target='localhost', node='pve', storage='local'):
         """
         Request handler for /storage route
         """

--- a/src/pve_exporter/http.py
+++ b/src/pve_exporter/http.py
@@ -11,7 +11,7 @@ from prometheus_client import CONTENT_TYPE_LATEST, Summary, Counter, generate_la
 from werkzeug.routing import Map, Rule
 from werkzeug.wrappers import Request, Response
 from werkzeug.exceptions import InternalServerError
-from pve_exporter.collector import collect_pve
+from pve_exporter.collector import collect_pve, collect_storage
 
 
 class PveExporterApplication:
@@ -46,9 +46,11 @@ class PveExporterApplication:
             Rule('/', endpoint='index'),
             Rule('/metrics', endpoint='metrics'),
             Rule('/pve', endpoint='pve'),
+            Rule('/storage', endpoint='storage'),
         ])
 
 
+    
     def on_pve(self, module='default', target='localhost', cluster='1', node='1'):
         """
         Request handler for /pve route
@@ -62,6 +64,27 @@ class PveExporterApplication:
                 cluster.lower() not in ['false', '0', ''],
                 node.lower() not in ['false', '0', ''],
                 self._collectors
+            )
+            response = Response(output)
+            response.headers['content-type'] = CONTENT_TYPE_LATEST
+            self._duration.labels(module).observe(time.time() - start)
+        else:
+            response = Response(f"Module '{module}' not found in config")
+            response.status_code = 400
+
+        return response
+
+    def on_storage(self, module='default', target='localhost', node='1', storage='local'):
+        """
+        Request handler for /storage route
+        """
+        if module in self._config:
+            start = time.time()
+            output = collect_storage(
+                self._config[module],
+                target,
+                node,
+                storage
             )
             response = Response(output)
             response.headers['content-type'] = CONTENT_TYPE_LATEST
@@ -106,13 +129,15 @@ class PveExporterApplication:
         """
 
         allowed_args = {
-            'pve': ['module', 'target', 'cluster', 'node']
+            'pve': ['module', 'target', 'cluster', 'node'],
+            'storage': ['module', 'target', 'node', 'storage']
         }
 
         view_registry = {
             'index': self.on_index,
             'metrics': self.on_metrics,
             'pve': self.on_pve,
+            'storage': self.on_storage,
         }
 
         params = dict(values)


### PR DESCRIPTION
Hi all,

This PR adds a few metrics for storage contents:

Example:

```
# HELP pve_storage_contents_ctime Proxmox storage contents ctime
# TYPE pve_storage_contents_ctime gauge
pve_storage_contents_ctime{content="backup",node="srv02",storage="pbs",vmid="100",volid="pbs:backup/vm/100/2025-02-09T02:33:33Z"} 1.739068413e+09
pve_storage_contents_ctime{content="backup",node="srv02",storage="pbs",vmid="100",volid="pbs:backup/vm/100/2025-02-09T07:36:08Z"} 1.739086568e+09

# HELP pve_storage_contents_bytes Proxmox storage contents size in bytes
# TYPE pve_storage_contents_bytes gauge
pve_storage_contents_bytes{content="backup",node="srv02",storage="pbs",vmid="100",volid="pbs:backup/vm/100/2025-02-09T02:33:33Z"} 2.17109760043e+011
pve_storage_contents_bytes{content="backup",node="srv02",storage="pbs",vmid="100",volid="pbs:backup/vm/100/2025-02-09T07:36:08Z"} 2.17109760045e+011

# HELP pve_storage_contents_verification Proxmox storage contents verification state
# TYPE pve_storage_contents_verification gauge
pve_storage_contents_verification{content="backup",node="srv02",state="ok",storage="pbs",vmid="100",volid="pbs:backup/vm/100/2025-02-09T02:33:33Z"} 1.0
pve_storage_contents_verification{content="backup",node="srv02",state="ok",storage="pbs",vmid="100",volid="pbs:backup/vm/100/2025-02-09T07:36:08Z"} 1.0
```

We are using these in our Prometheus alerting to validate that backups have been created on time (by checking the newest ctime and making sure it is in sync with the respective VM's policies.

I decided to expose those under a separate endpoint which is scraped like this:

```
GET /storage?target=10.10.10.10&node=srv02&storage=pbs
```

This allows for a flexible scraping of multiple storages and nodes.

It seems the API user needs the `PVEDatastoreAdmin` role for the scraping to work, I will try to narrow down the requirements more.

Please let me know what you think about the approach of having a separate endpoint and if you'd be interested in merging this. I'd happily add some documentation to the PR then.