### PR TITLE
Replace running total gauge metrics with counters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,12 +166,12 @@ Here's an example of the metrics exported.
     # HELP pve_network_receive_bytes_total The amount of traffic in bytes that was sent to the guest over the network since it was started. (for types 'qemu' and 'lxc')
     # TYPE pve_network_receive_bytes_total counter
     pve_network_receive_bytes_total{id="qemu/100"} 1.529756162e+09
-    # HELP pve_disk_write_bytes The amount of bytes the guest wrote to its block devices since the guest was started. This info is not available for all storage types. (for types 'qemu' and 'lxc') DEPRECATED: use pve_disk_write_bytes_total instead.
+    # HELP pve_disk_write_bytes The amount of bytes the guest wrote to its block devices since the guest was started. This info is not available for all storage types. (for types 'qemu' and 'lxc') DEPRECATED: use pve_disk_written_bytes_total instead.
     # TYPE pve_disk_write_bytes gauge
     pve_disk_write_bytes{id="qemu/100"} 1.50048127488e+011
-    # HELP pve_disk_write_bytes_total The amount of bytes the guest wrote to its block devices since the guest was started. This info is not available for all storage types. (for types 'qemu' and 'lxc')
-    # TYPE pve_disk_write_bytes_total counter
-    pve_disk_write_bytes_total{id="qemu/100"} 1.50048127488e+011
+    # HELP pve_disk_written_bytes_total The amount of bytes the guest wrote to its block devices since the guest was started. This info is not available for all storage types. (for types 'qemu' and 'lxc')
+    # TYPE pve_disk_written_bytes_total counter
+    pve_disk_written_bytes_total{id="qemu/100"} 1.50048127488e+011
     # HELP pve_disk_read_bytes The amount of bytes the guest read from its block devices since the guest was started. This info is not available for all storage types. (for types 'qemu' and 'lxc') DEPRECATED: use pve_disk_read_bytes_total instead.
     # TYPE pve_disk_read_bytes gauge
     pve_disk_read_bytes{id="qemu/100"} 7.473739264e+09

--- a/src/pve_exporter/collector/cluster.py
+++ b/src/pve_exporter/collector/cluster.py
@@ -293,7 +293,7 @@ class ClusterResourcesCollector:
                     "The amount of bytes the guest wrote to its block devices since the guest was "
                     "started. This info is not available for all storage types. "
                     "(for types 'qemu' and 'lxc') "
-                    "DEPRECATED: Use pve_disk_write_bytes_total instead."
+                    "DEPRECATED: Use pve_disk_written_bytes_total instead."
                 ),
                 labels=['id']),
             'diskread': GaugeMetricFamily(
@@ -339,7 +339,7 @@ class ClusterResourcesCollector:
                 ),
                 labels=['id']),
             'diskwrite': CounterMetricFamily(
-                'pve_disk_write_bytes_total',
+                'pve_disk_written_bytes_total',
                 (
                     "The amount of bytes the guest wrote to its block devices since the guest was "
                     "started. This info is not available for all storage types. "


### PR DESCRIPTION
This adds 4 new counter metrics for read/write disk bytes and receive/transmite network bytes. These counters duplicate the functionality of existing gauge metrics, which are marked as deprecated.

Per prometheus docs, "a gauge is a metric that represents a single numerical value that can arbitrarily go up and down" and a counter " is a cumulative metric that represents a single monotonically increasing counter".

Tested on my own PVE install, swapping from gauge to counters gives the same stats (and no Grafana warnings).

Fixes https://github.com/prometheus-pve/prometheus-pve-exporter/issues/285
