### PR TITLE
Configurable threads

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ Usage
                         [--collector.target-metrics | --no-collector.target-metrics]
                         [--config.file CONFIG_FILE]
                         [--web.listen-address WEB_LISTEN_ADDRESS]
+                        [--web.threads WEB_THREADS]
                         [--server.keyfile SERVER_KEYFILE]
                         [--server.certfile SERVER_CERTFILE]
 
@@ -69,6 +70,9 @@ Usage
       --web.listen-address WEB_LISTEN_ADDRESS
                             Address on which to expose metrics and web server.
                             ([::]:9221)
+      --web.threads WEB_THREADS
+                            Number of worker threads for handling requests.
+                            Increase this when scraping many targets concurrently. (5)
       --server.keyfile SERVER_KEYFILE
                             SSL key for server
       --server.certfile SERVER_CERTFILE

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -78,6 +78,12 @@ def main():
                             'Address on which to expose metrics and web server. '
                             '([::]:9221)'
                         ))
+    parser.add_argument('--web.threads', type=int,
+                        dest='web_threads', default=5,
+                        help=(
+                            'Number of worker threads for handling requests. '
+                            'Increase this when scraping many targets concurrently. (5)'
+                        ))
     parser.add_argument('--server.keyfile', dest='server_keyfile',
                         help='SSL key for server')
     parser.add_argument('--server.certfile', dest='server_certfile',
@@ -108,7 +114,7 @@ def main():
 
     gunicorn_options = {
         'bind': f'{params.web_listen_address}',
-        'threads': 2,
+        'threads': params.web_threads,
         'keyfile': params.server_keyfile,
         'certfile': params.server_certfile,
     }


### PR DESCRIPTION
Make the number of threads configurable.

Context - We use the exporter, running in Kubernetes, to scrape a medium cluster of around 10 nodes, some of which are offline due to hardware reasons. The exporter seems to get clogged up with these offline servers, and the liveness/readiness probes for the pod (configured to probe `/`) sometimes takes >5s to respond. Increasing the number of ~workers~ threads should help with this, and general performance.