### PR TITLE
ci: pin PyPI workflow actions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         run: python -m build .
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           path: ./dist
           name: dist
@@ -39,10 +39,10 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ./dist
           name: dist
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary
- pin the PyPI release workflow actions to immutable SHAs
- harden the trusted-publishing surface without changing build or publish behavior

## Why
The `Upload Python Package` workflow publishes to PyPI with `id-token: write`, so floating action refs are a larger supply-chain risk than they need to be.

## Scope
- `.github/workflows/pypi.yml`

## Validation
- `git diff --check`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path(r'C:\Users\Eddie\.codex\worktrees\prometheus-pve-pypi-pin\.github\workflows\pypi.yml').read_text(encoding='utf-8'))"`
- `actionlint` not available in this shell

## Risk Notes
- workflow-only change
- no behavior change intended
- no package/runtime code touched