### PR TITLE
feat: add qdevice collector

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ Usage
                         [--collector.cluster | --no-collector.cluster]
                         [--collector.resources | --no-collector.resources]
                         [--collector.backup-info | --no-collector.backup-info]
+                        [--collector.qdevice | --no-collector.qdevice]
                         [--collector.config | --no-collector.config]
                         [--collector.replication | --no-collector.replication]
                         [--collector.subscription | --no-collector.subscription]
@@ -104,6 +105,8 @@ Usage
       --collector.backup-info, --no-collector.backup-info
                             Exposes information about guests which are not covered
                             by any backup job
+      --collector.qdevice, --no-collector.qdevice
+                            Exposes PVE QDevice connection state
 
     node collectors:
       node collectors are run if the url parameter node=1 is set and skipped if
@@ -279,6 +282,12 @@ Here's an example of the metrics exported.
     # HELP pve_subscription_next_due_timestamp_seconds Subscription next due date as Unix timestamp
     # TYPE pve_subscription_next_due_timestamp_seconds gauge
     pve_subscription_next_due_timestamp_seconds{id="node/proxmox"} 1.713382503e+09
+    # HELP pve_qdevice_up Proxmox VE QDevice is connected (1) or not (0)
+    # TYPE pve_qdevice_up gauge
+    pve_qdevice_up{id="cluster/pvc"} 1.0
+    # HELP pve_qdevice_info Proxmox VE QDevice info (1 if configured)
+    # TYPE pve_qdevice_info gauge
+    pve_qdevice_info{id="cluster/pvc",model="Net",algorithm="Fifty-Fifty split",qnetd_host="10.0.0.1:5403",tie_breaker="Node with lowest node ID",state="Connected"} 1.0
     # HELP pve_onboot_status Proxmox vm config onboot value
     # TYPE pve_onboot_status gauge
     pve_onboot_status{id="qemu/201",node="proxmox",type="qemu"} 1.0

--- a/src/pve_exporter/cli.py
+++ b/src/pve_exporter/cli.py
@@ -42,6 +42,9 @@ def main():
                               action=BooleanOptionalAction, default=True,
                               help=('Exposes information about guests which are not '
                                     'covered by any backup job'))
+    clusterflags.add_argument('--collector.qdevice', dest='collector_qdevice',
+                              action=BooleanOptionalAction, default=True,
+                              help='Exposes PVE QDevice connection state')
 
     nodeflags = parser.add_argument_group('node collectors', description=(
         'node collectors are run if the url parameter node=1 is set and '
@@ -94,7 +97,8 @@ def main():
         resources=params.collector_resources,
         backup_info=params.collector_backup_info,
         config=params.collector_config,
-        replication=params.collector_replication
+        replication=params.collector_replication,
+        qdevice=params.collector_qdevice
     )
     scrape_metrics.API_METRICS_ENABLED = params.api_metrics_enabled
     scrape_metrics.TARGET_METRICS_ENABLED = params.target_metrics_enabled

--- a/src/pve_exporter/collector/__init__.py
+++ b/src/pve_exporter/collector/__init__.py
@@ -13,7 +13,8 @@ from pve_exporter.collector.cluster import (
     ClusterNodeCollector,
     VersionCollector,
     ClusterInfoCollector,
-    BackupInfoCollector
+    BackupInfoCollector,
+    QDeviceCollector
 )
 from pve_exporter.collector.node import (
     NodeConfigCollector,
@@ -30,7 +31,8 @@ CollectorsOptions = collections.namedtuple('CollectorsOptions', [
     'resources',
     'backup_info',
     'config',
-    'replication'
+    'replication',
+    'qdevice'
 ])
 
 
@@ -52,6 +54,8 @@ def collect_pve(config, host, cluster, node, options: CollectorsOptions):
         registry.register(VersionCollector(pve))
     if cluster and options.backup_info:
         registry.register(BackupInfoCollector(pve))
+    if cluster and options.qdevice:
+        registry.register(QDeviceCollector(pve))
     if node and options.subscription:
         registry.register(SubscriptionCollector(pve))
     if node and options.config:

--- a/src/pve_exporter/collector/cluster.py
+++ b/src/pve_exporter/collector/cluster.py
@@ -7,6 +7,7 @@ import itertools
 import typing
 
 from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily
+from proxmoxer import ResourceException
 
 
 class StatusCollector:
@@ -147,6 +148,73 @@ class ClusterInfoCollector:
                 info_metrics.add_metric(label_values, 1)
 
             yield info_metrics
+
+
+class QDeviceCollector:
+    """
+    Collects Proxmox VE QDevice connection state from the local node's view.
+    For manual test: "pvesh get /cluster/config/qdevice"
+
+    # HELP pve_qdevice_up Proxmox VE QDevice is connected (1) or not (0)
+    # TYPE pve_qdevice_up gauge
+    pve_qdevice_up{id="cluster/pvec"} 1.0
+    # HELP pve_qdevice_info Proxmox VE QDevice info (1 if configured)
+    # TYPE pve_qdevice_info gauge
+    pve_qdevice_info{id="cluster/pvec",model="Net",algorithm="Fifty-Fifty split",
+        qnetd_host="10.0.0.1:5403",tie_breaker="Node with lowest node ID",
+        state="Connected"} 1.0
+    """
+
+    # Maps API response keys to Prometheus label names.
+    LABEL_MAP = {
+        'Model': 'model',
+        'Algorithm': 'algorithm',
+        'QNetd host': 'qnetd_host',
+        'Tie-breaker': 'tie_breaker',
+        'State': 'state',
+    }
+
+    def __init__(self, pve):
+        self._pve = pve
+
+    def collect(self):  # pylint: disable=missing-docstring
+        cluster_id = None
+        for entry in self._pve.cluster.status.get():
+            if entry['type'] == 'cluster':
+                cluster_id = f"cluster/{entry['name']}"
+                break
+
+        if cluster_id is None:
+            return
+
+        try:
+            qdevice = self._pve.cluster.config.qdevice.get()
+        except ResourceException:
+            # No QDevice configured on this cluster.
+            return
+
+        if not qdevice:
+            return
+
+        label_names = ['id'] + list(self.LABEL_MAP.values())
+        label_values = [cluster_id] + [
+            str(qdevice.get(api_key, '')) for api_key in self.LABEL_MAP
+        ]
+
+        info_metric = GaugeMetricFamily(
+            'pve_qdevice_info',
+            'Proxmox VE QDevice info (1 if configured)',
+            labels=label_names)
+        info_metric.add_metric(label_values, 1)
+
+        up_metric = GaugeMetricFamily(
+            'pve_qdevice_up',
+            'Proxmox VE QDevice is connected (1) or not (0)',
+            labels=['id'])
+        up_metric.add_metric([cluster_id], qdevice.get('State') == 'Connected')
+
+        yield up_metric
+        yield info_metric
 
 
 class HighAvailabilityStateMetric(GaugeMetricFamily):


### PR DESCRIPTION
## Summary

Adds a `QDeviceCollector` (cluster group, new `--collector.qdevice` flag, default on) that exposes the QDevice connection state via:

- `pve_qdevice_up{id="cluster/<name>"}` — `1` if `State == "Connected"`, else `0`. Absent if no QDevice configured.
- `pve_qdevice_info{id, model, algorithm, qnetd_host, tie_breaker, state}` — info metric.

## API Reference

```
$ pvesh get /cluster/config/qdevice -o json

# Configured + connected
{"Algorithm":"Fifty-Fifty split","Last poll call":"2026-05-13T13:43:24 (cast vote)",
 "Model":"Net","QNetd host":"X.X.X.X:5403","State":"Connected",
 "Tie-breaker":"Node with lowest node ID"}

# Configured + disconnected
{"Algorithm":"Fifty-Fifty split","Last poll call":"2026-05-13T13:43:00",
 "Model":"Net","QNetd host":"X.X.X.X:5403","State":"Connect failed",
 "Tie-breaker":"Node with lowest node ID"}

# Not configured
{}
```

## Testing

I tested the new collector against:
-  2-node cluster, QDevice configured and online
-  2-node cluster, QDevice configured and offline
-  5-node cluster, no QDevice