### PR TITLE
Bump minimum python version to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "prometheus-pve-exporter"
 version = "3.9.0"
 authors = [{ name = "Lorenz Schori", email = "lo@znerol.ch" }]
 description = "Proxmox VE exporter for the Prometheus monitoring system."
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 keywords = ["prometheus", "exporter", "network", "monitoring", "proxmox"]
 license = { text = "Apache-2.0" }
 classifiers = [


### PR DESCRIPTION
* Bump minimum Python version requirements to 3.11 / Debian `bookworm (oldstable)`.
* Drop support for Python 3.9 / Debian `buster (oldoldstable)`.
* This should prevent `dependabot` from downgrading various dependencies.